### PR TITLE
Add lang collections

### DIFF
--- a/staging.sh
+++ b/staging.sh
@@ -164,7 +164,26 @@ function make_base_zipfile () {
          collection-plainextra \
          collection-publishers \
          collection-science \
-         collection-xetex
+         collection-xetex \
+         collection-langafrican \
+         collection-langarabic \
+         collection-langchinese \
+         collection-langcjk \
+         collection-langcyrillic \
+         collection-langczechslovak \
+         collection-langenglish \
+         collection-langeuropean \
+         collection-langfrench \
+         collection-langgerman \
+         collection-langgreek \
+         collection-langindic \
+         collection-langitalian \
+         collection-langjapanese \
+         collection-langkorean \
+         collection-langother \
+         collection-langpolish \
+         collection-langportuguese \
+         collection-langspanish
     )
 
     # Some manual fiddles for format file generation


### PR DESCRIPTION
Fixes https://github.com/tectonic-typesetting/tectonic/issues/30

The language collections names was obtained with the command:

curl http://ftp.math.purdue.edu/mirrors/ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb | egrep -o collection-lang[^\.]+$ | sort -h | uniq